### PR TITLE
fix "uninitialized value" warnings

### DIFF
--- a/lib/Plack/App/PHPCGI.pm
+++ b/lib/Plack/App/PHPCGI.pm
@@ -59,9 +59,9 @@ sub wrap_php {
         
         my $res = '';
         while (waitpid($pid, WNOHANG) <= 0) {
-            $res .= do { local $/; <$stdoutr> };
+            $res .= do { local $/; my $str = <$stdoutr>; defined $str ? $str : '' };
         }
-        $res .= do { local $/; <$stdoutr> };
+        $res .= do { local $/; my $str = <$stdoutr>; defined $str ? $str : '' };
         
         if (POSIX::WIFEXITED($?)) {
             return CGI::Parse::PSGI::parse_cgi_output(\$res);


### PR DESCRIPTION
Starting with perl 5.19.4, these lines warn with:
Use of uninitialized value in concatenation (.) or string at .../Plack/App/PHPCGI.pm line 64, <$stdoutr> line 1.

This is because of this blead commit:
http://perl5.git.perl.org/perl.git/commitdiff/4f62cd62aef0fcb9cc527c8aea4d04423189cfd5
...which added the check for undef values in more situations.
